### PR TITLE
Improve logging of configuration errors

### DIFF
--- a/PIATunnel/Sources/AppExtension/PIATunnelProvider+Configuration.swift
+++ b/PIATunnel/Sources/AppExtension/PIATunnelProvider+Configuration.swift
@@ -125,20 +125,20 @@ extension PIATunnelProvider {
         
         init(protocolConfiguration: NEVPNProtocol) throws {
             guard let address = protocolConfiguration.serverAddress else {
-                throw TunnelError.configuration(field: "protocolConfiguration.serverAddress")
+                throw ProviderError.configuration(field: "protocolConfiguration.serverAddress")
             }
             let addressComponents = address.components(separatedBy: ":")
             guard (addressComponents.count == 2) else {
-                throw TunnelError.configuration(field: "protocolConfiguration.serverAddress (hostname:port)")
+                throw ProviderError.configuration(field: "protocolConfiguration.serverAddress (hostname:port)")
             }
             guard let username = protocolConfiguration.username else {
-                throw TunnelError.credentials(field: "protocolConfiguration.username")
+                throw ProviderError.credentials(field: "protocolConfiguration.username")
             }
             guard let passwordReference = protocolConfiguration.passwordReference else {
-                throw TunnelError.credentials(field: "protocolConfiguration.passwordReference")
+                throw ProviderError.credentials(field: "protocolConfiguration.passwordReference")
             }
             guard let password = try? Keychain.password(for: username, reference: passwordReference) else {
-                throw TunnelError.credentials(field: "protocolConfiguration.passwordReference (keychain)")
+                throw ProviderError.credentials(field: "protocolConfiguration.passwordReference (keychain)")
             }
             
             hostname = addressComponents[0]
@@ -207,13 +207,13 @@ extension PIATunnelProvider {
             let S = Configuration.Keys.self
 
             guard let appGroup = providerConfiguration[S.appGroup] as? String else {
-                throw TunnelError.configuration(field: "protocolConfiguration.providerConfiguration[\(S.appGroup)]")
+                throw ProviderError.configuration(field: "protocolConfiguration.providerConfiguration[\(S.appGroup)]")
             }
             guard let cipherAlgorithm = providerConfiguration[S.cipherAlgorithm] as? String, let cipher = Cipher(rawValue: cipherAlgorithm) else {
-                throw TunnelError.configuration(field: "protocolConfiguration.providerConfiguration[\(S.cipherAlgorithm)]")
+                throw ProviderError.configuration(field: "protocolConfiguration.providerConfiguration[\(S.cipherAlgorithm)]")
             }
             guard let digestAlgorithm = providerConfiguration[S.digestAlgorithm] as? String, let digest = Digest(rawValue: digestAlgorithm) else {
-                throw TunnelError.configuration(field: "protocolConfiguration.providerConfiguration[\(S.digestAlgorithm)]")
+                throw ProviderError.configuration(field: "protocolConfiguration.providerConfiguration[\(S.digestAlgorithm)]")
             }
 
             // fallback to .rsa2048 in < 0.7 configurations (ca/caDigest)
@@ -239,7 +239,7 @@ extension PIATunnelProvider {
             shouldDebug = providerConfiguration[S.debug] as? Bool ?? false
             if shouldDebug {
                 guard let debugLogKey = providerConfiguration[S.debugLogKey] as? String else {
-                    throw TunnelError.configuration(field: "protocolConfiguration.providerConfiguration[\(S.debugLogKey)]")
+                    throw ProviderError.configuration(field: "protocolConfiguration.providerConfiguration[\(S.debugLogKey)]")
                 }
                 self.debugLogKey = debugLogKey
             } else {
@@ -336,7 +336,7 @@ extension PIATunnelProvider {
          
          - Parameter from: The map to parse.
          - Returns: The parsed `PIATunnelProvider.Configuration` object.
-         - Throws: `TunnelError.configuration` if `providerConfiguration` is incomplete.
+         - Throws: `ProviderError.configuration` if `providerConfiguration` is incomplete.
          */
         public static func parsed(from providerConfiguration: [String: Any]) throws -> Configuration {
             let builder = try ConfigurationBuilder(providerConfiguration: providerConfiguration)
@@ -375,7 +375,7 @@ extension PIATunnelProvider {
          - Parameter bundleIdentifier: The provider bundle identifier required to locate the tunnel extension.
          - Parameter endpoint: The `PIATunnelProvider.AuthenticatedEndpoint` the tunnel will connect to.
          - Returns: The generated `NETunnelProviderProtocol` object.
-         - Throws: `TunnelError.configuration` if unable to store the `endpoint.password` to the `appGroup` keychain.
+         - Throws: `ProviderError.configuration` if unable to store the `endpoint.password` to the `appGroup` keychain.
          */
         public func generatedTunnelProtocol(withBundleIdentifier bundleIdentifier: String, endpoint: AuthenticatedEndpoint) throws -> NETunnelProviderProtocol {
             let protocolConfiguration = NETunnelProviderProtocol()
@@ -384,7 +384,7 @@ extension PIATunnelProvider {
             do {
                 try keychain.set(password: endpoint.password, for: endpoint.username)
             } catch _ {
-                throw TunnelError.credentials(field: "keychain.set()")
+                throw ProviderError.credentials(field: "keychain.set()")
             }
             
             protocolConfiguration.providerBundleIdentifier = bundleIdentifier

--- a/PIATunnel/Sources/AppExtension/PIATunnelProvider+Configuration.swift
+++ b/PIATunnel/Sources/AppExtension/PIATunnelProvider+Configuration.swift
@@ -125,20 +125,20 @@ extension PIATunnelProvider {
         
         init(protocolConfiguration: NEVPNProtocol) throws {
             guard let address = protocolConfiguration.serverAddress else {
-                throw TunnelError.configuration
+                throw TunnelError.configuration(field: "protocolConfiguration.serverAddress")
             }
             let addressComponents = address.components(separatedBy: ":")
             guard (addressComponents.count == 2) else {
-                throw TunnelError.configuration
+                throw TunnelError.configuration(field: "protocolConfiguration.serverAddress (hostname:port)")
             }
             guard let username = protocolConfiguration.username else {
-                throw TunnelError.credentials
+                throw TunnelError.credentials(field: "protocolConfiguration.username")
             }
             guard let passwordReference = protocolConfiguration.passwordReference else {
-                throw TunnelError.credentials
+                throw TunnelError.credentials(field: "protocolConfiguration.passwordReference")
             }
             guard let password = try? Keychain.password(for: username, reference: passwordReference) else {
-                throw TunnelError.credentials
+                throw TunnelError.credentials(field: "protocolConfiguration.passwordReference (keychain)")
             }
             
             hostname = addressComponents[0]
@@ -207,13 +207,13 @@ extension PIATunnelProvider {
             let S = Configuration.Keys.self
 
             guard let appGroup = providerConfiguration[S.appGroup] as? String else {
-                throw TunnelError.configuration
+                throw TunnelError.configuration(field: "protocolConfiguration.providerConfiguration[\(S.appGroup)]")
             }
             guard let cipherAlgorithm = providerConfiguration[S.cipherAlgorithm] as? String, let cipher = Cipher(rawValue: cipherAlgorithm) else {
-                throw TunnelError.configuration
+                throw TunnelError.configuration(field: "protocolConfiguration.providerConfiguration[\(S.cipherAlgorithm)]")
             }
             guard let digestAlgorithm = providerConfiguration[S.digestAlgorithm] as? String, let digest = Digest(rawValue: digestAlgorithm) else {
-                throw TunnelError.configuration
+                throw TunnelError.configuration(field: "protocolConfiguration.providerConfiguration[\(S.digestAlgorithm)]")
             }
 
             // fallback to .rsa2048 in < 0.7 configurations (ca/caDigest)
@@ -239,7 +239,7 @@ extension PIATunnelProvider {
             shouldDebug = providerConfiguration[S.debug] as? Bool ?? false
             if shouldDebug {
                 guard let debugLogKey = providerConfiguration[S.debugLogKey] as? String else {
-                    throw TunnelError.configuration
+                    throw TunnelError.configuration(field: "protocolConfiguration.providerConfiguration[\(S.debugLogKey)]")
                 }
                 self.debugLogKey = debugLogKey
             } else {
@@ -384,7 +384,7 @@ extension PIATunnelProvider {
             do {
                 try keychain.set(password: endpoint.password, for: endpoint.username)
             } catch _ {
-                throw TunnelError.configuration
+                throw TunnelError.credentials(field: "keychain.set()")
             }
             
             protocolConfiguration.providerBundleIdentifier = bundleIdentifier

--- a/PIATunnel/Sources/AppExtension/PIATunnelProvider+Configuration.swift
+++ b/PIATunnel/Sources/AppExtension/PIATunnelProvider+Configuration.swift
@@ -132,13 +132,13 @@ extension PIATunnelProvider {
                 throw TunnelError.configuration
             }
             guard let username = protocolConfiguration.username else {
-                throw TunnelError.configuration
+                throw TunnelError.credentials
             }
             guard let passwordReference = protocolConfiguration.passwordReference else {
-                throw TunnelError.configuration
+                throw TunnelError.credentials
             }
             guard let password = try? Keychain.password(for: username, reference: passwordReference) else {
-                throw TunnelError.configuration
+                throw TunnelError.credentials
             }
             
             hostname = addressComponents[0]

--- a/PIATunnel/Sources/AppExtension/PIATunnelProvider+Interaction.swift
+++ b/PIATunnel/Sources/AppExtension/PIATunnelProvider+Interaction.swift
@@ -38,7 +38,7 @@ extension PIATunnelProvider {
     }
 
     /// The errors raised by `PIATunnelProvider`.
-    public enum TunnelError: Error {
+    public enum ProviderError: Error {
 
         /// The `PIATunnelProvider.Configuration` provided is incorrect or incomplete.
         case configuration(field: String)

--- a/PIATunnel/Sources/AppExtension/PIATunnelProvider+Interaction.swift
+++ b/PIATunnel/Sources/AppExtension/PIATunnelProvider+Interaction.swift
@@ -43,6 +43,9 @@ extension PIATunnelProvider {
         /// The `PIATunnelProvider.Configuration` provided is incorrect or incomplete.
         case configuration
         
+        /// Credentials are missing or protected (e.g. device locked).
+        case credentials
+        
         /// The pseudo-random number generator could not be initialized.
         case prngInitialization
         

--- a/PIATunnel/Sources/AppExtension/PIATunnelProvider+Interaction.swift
+++ b/PIATunnel/Sources/AppExtension/PIATunnelProvider+Interaction.swift
@@ -41,10 +41,10 @@ extension PIATunnelProvider {
     public enum TunnelError: Error {
 
         /// The `PIATunnelProvider.Configuration` provided is incorrect or incomplete.
-        case configuration
+        case configuration(field: String)
         
         /// Credentials are missing or protected (e.g. device locked).
-        case credentials
+        case credentials(field: String)
         
         /// The pseudo-random number generator could not be initialized.
         case prngInitialization

--- a/PIATunnel/Sources/AppExtension/PIATunnelProvider.swift
+++ b/PIATunnel/Sources/AppExtension/PIATunnelProvider.swift
@@ -95,7 +95,13 @@ open class PIATunnelProvider: NEPacketTunnelProvider {
             try cfg = Configuration.parsed(from: providerConfiguration)
             self.bundleIdentifier = bundleIdentifier
         } catch let e {
-            NSLog("Tunnel configuration incomplete!")
+            switch e {
+            case TunnelError.credentials:
+                NSLog("Tunnel credentials unavailable!")
+                
+            default:
+                NSLog("Tunnel configuration incomplete!")
+            }
             cancelTunnelWithError(e)
             return
         }


### PR DESCRIPTION
Exceptions thrown at tunnel start time, don't offer any hint at what part of the configuration is actually missing or incomplete. Additionally, credentials may be unavailable for issues beyond user input (e.g. keychain). Better be more descriptive.

Also, rename `TunnelError` to `ProviderError` to highlight the error context, as such error is raised by the packet tunnel provider. Avoid confusion with `PIATunnelError*` raised instead by core components.