### PR TITLE
Rewrite without loop

### DIFF
--- a/PIATunnel/Sources/AppExtension/InterfaceObserver.swift
+++ b/PIATunnel/Sources/AppExtension/InterfaceObserver.swift
@@ -27,7 +27,7 @@ class InterfaceObserver: NSObject {
         self.queue = queue
 
         let timer = DispatchSource.makeTimerSource(flags: DispatchSource.TimerFlags(rawValue: UInt(0)), queue: queue)
-        timer.schedule(deadline: DispatchTime.now(), repeating: .seconds(2))
+        timer.schedule(deadline: .now(), repeating: .seconds(2))
         timer.setEventHandler {
             self.fireWifiChangeObserver()
         }

--- a/PIATunnel/Sources/AppExtension/PIATunnelProvider.swift
+++ b/PIATunnel/Sources/AppExtension/PIATunnelProvider.swift
@@ -254,7 +254,7 @@ open class PIATunnelProvider: NEPacketTunnelProvider {
             //
             // socketActivity makes sense, given that any other error would normally come
             // from SessionProxy.stopError. other paths to disposeTunnel() are only coming
-            // from stopTunnel(), in which case we don't need feed an error parameter to
+            // from stopTunnel(), in which case we don't need to feed an error parameter to
             // the stop completion handler
             //
             pendingStartHandler?(error ?? ProviderError.socketActivity)

--- a/PIATunnel/Sources/AppExtension/Utils.swift
+++ b/PIATunnel/Sources/AppExtension/Utils.swift
@@ -10,7 +10,6 @@ import Foundation
 
 extension DispatchQueue {
     func schedule(after: DispatchTimeInterval, block: @escaping () -> Void) {
-        let deadline = DispatchTime.now() + after
-        asyncAfter(deadline: deadline, execute: block)
+        asyncAfter(deadline: .now() + after, execute: block)
     }
 }

--- a/PIATunnel/Sources/Core/SessionProxy.swift
+++ b/PIATunnel/Sources/Core/SessionProxy.swift
@@ -398,8 +398,7 @@ public class SessionProxy {
         ping()
         
         guard (negotiationKey.controlState == .connected) else {
-            let nextTime = DispatchTime.now() + Configuration.tickInterval
-            queue.asyncAfter(deadline: nextTime) { [weak self] in
+            queue.asyncAfter(deadline: .now() + Configuration.tickInterval) { [weak self] in
                 self?.loopNegotiation()
             }
             return

--- a/PIATunnel/Sources/Core/SessionProxy.swift
+++ b/PIATunnel/Sources/Core/SessionProxy.swift
@@ -396,11 +396,11 @@ public class SessionProxy {
                 flushControlQueue()
             }
             ping()
-            
-            let nextTime = DispatchTime.now() + Configuration.tickInterval
-            queue.asyncAfter(deadline: nextTime) {
-                self.loop()
-            }
+        }
+
+        let nextTime = DispatchTime.now() + Configuration.tickInterval
+        queue.asyncAfter(deadline: nextTime) {
+            self.loop()
         }
     }
 

--- a/PIATunnel/Sources/Core/SessionProxy.swift
+++ b/PIATunnel/Sources/Core/SessionProxy.swift
@@ -361,7 +361,6 @@ public class SessionProxy {
         loopNegotiation()
     }
     
-    // TODO: convert quasi-busy-waiting loop to DispatchQueue blocks (may improve battery usage)
     private func loopNegotiation() {
         guard let link = link else {
             return
@@ -379,23 +378,10 @@ public class SessionProxy {
             return
         }
             
-//        if let stopMethod = stopMethod {
-//            switch stopMethod {
-//            case .shutdown:
-//                doShutdown(error: stopError)
-//
-//            case .reconnect:
-//                doReconnect(error: stopError)
-//            }
-//            return
-//        }
-        
-//        maybeRenegotiate()
         if !isReliableLink {
             pushRequest()
             flushControlQueue()
         }
-//        ping()
         
         guard (negotiationKey.controlState == .connected) else {
             queue.asyncAfter(deadline: .now() + Configuration.tickInterval) { [weak self] in

--- a/PIATunnel/Sources/Core/SessionProxy.swift
+++ b/PIATunnel/Sources/Core/SessionProxy.swift
@@ -369,34 +369,32 @@ public class SessionProxy {
             return
         }
 
-        autoreleasepool {
-            guard !negotiationKey.didHardResetTimeOut(link: link) else {
-                doReconnect(error: SessionError.connectionTimeout)
-                return
-            }
-            guard !negotiationKey.didNegotiationTimeOut(link: link) else {
-                doShutdown(error: SessionError.connectionTimeout)
-                return
-            }
-            
-            if let stopMethod = stopMethod {
-                switch stopMethod {
-                case .shutdown:
-                    doShutdown(error: stopError)
-
-                case .reconnect:
-                    doReconnect(error: stopError)
-                }
-                return
-            }
-        
-            maybeRenegotiate()
-            if !isReliableLink {
-                pushRequest()
-                flushControlQueue()
-            }
-            ping()
+        guard !negotiationKey.didHardResetTimeOut(link: link) else {
+            doReconnect(error: SessionError.connectionTimeout)
+            return
         }
+        guard !negotiationKey.didNegotiationTimeOut(link: link) else {
+            doShutdown(error: SessionError.connectionTimeout)
+            return
+        }
+            
+        if let stopMethod = stopMethod {
+            switch stopMethod {
+            case .shutdown:
+                doShutdown(error: stopError)
+
+            case .reconnect:
+                doReconnect(error: stopError)
+            }
+            return
+        }
+        
+        maybeRenegotiate()
+        if !isReliableLink {
+            pushRequest()
+            flushControlQueue()
+        }
+        ping()
 
         let nextTime = DispatchTime.now() + Configuration.tickInterval
         queue.asyncAfter(deadline: nextTime) {


### PR DESCRIPTION
The original code was not written with mobile and in particular iOS lifecycle in mind. The code today is much closer to a busy waiting and can waste CPU cycles (read battery). This PR should mitigate #4.

Proposal:

- Take out any part of the main loop that can be rethought with DispatchQueue.
- Keep loop fashion for negotiation only, to speed it up when using an unreliable link.
- Send keep-alive packets only and only if there has not been data activity.