### PR TITLE
Clean up properly between reconnections

### DIFF
--- a/PIATunnel/Sources/AppExtension/PIATunnelProvider.swift
+++ b/PIATunnel/Sources/AppExtension/PIATunnelProvider.swift
@@ -234,10 +234,6 @@ open class PIATunnelProvider: NEPacketTunnelProvider {
     private func disposeTunnel(error: Error?) {
         flushLog()
         
-        proxy = nil
-        let fm = FileManager.default
-        try? fm.removeItem(at: tmpCaURL)
-        
         // failed to start
         if (pendingStartHandler != nil) {
             
@@ -267,6 +263,8 @@ open class PIATunnelProvider: NEPacketTunnelProvider {
         }
         // stopped externally, unrecoverable
         else {
+            let fm = FileManager.default
+            try? fm.removeItem(at: tmpCaURL)
             cancelTunnelWithError(error)
         }
     }

--- a/PIATunnel/Sources/AppExtension/PIATunnelProvider.swift
+++ b/PIATunnel/Sources/AppExtension/PIATunnelProvider.swift
@@ -146,6 +146,7 @@ open class PIATunnelProvider: NEPacketTunnelProvider {
         let proxy: SessionProxy
         do {
             proxy = try SessionProxy(queue: tunnelQueue, encryption: encryption, credentials: credentials)
+            proxy.setTunnel(tunnel: NETunnelInterface(impl: packetFlow))
         } catch let e {
             cancelTunnelWithError(e)
             return
@@ -347,9 +348,6 @@ extension PIATunnelProvider: SessionProxyDelegate {
             }
             
             log.info("Tunnel interface is now UP")
-            self.tunnelQueue.sync {
-                proxy.setTunnel(tunnel: NETunnelInterface(impl: self.packetFlow))
-            }
             
             self.pendingStartHandler?(nil)
             self.pendingStartHandler = nil

--- a/PIATunnel/Sources/AppExtension/Transport/NETCPSocket.swift
+++ b/PIATunnel/Sources/AppExtension/Transport/NETCPSocket.swift
@@ -21,9 +21,7 @@ class NETCPSocket: NSObject, GenericSocket {
     
     private weak var queue: DispatchQueue?
     
-    var endpoint: NWEndpoint {
-        return impl.endpoint
-    }
+    let endpoint: NWEndpoint
     
     var remoteAddress: String? {
         return (impl.remoteAddress as? NWHostEndpoint)?.hostname
@@ -37,6 +35,7 @@ class NETCPSocket: NSObject, GenericSocket {
     
     init(impl: NWTCPConnection) {
         self.impl = impl
+        endpoint = impl.endpoint
         isActive = false
     }
     

--- a/PIATunnel/Sources/AppExtension/Transport/NETunnelInterface.swift
+++ b/PIATunnel/Sources/AppExtension/Transport/NETunnelInterface.swift
@@ -10,9 +10,13 @@ import Foundation
 import NetworkExtension
 
 class NETunnelInterface: TunnelInterface {
-    private let impl: NEPacketTunnelFlow
+    private weak var impl: NEPacketTunnelFlow?
     
-    init(impl: NEPacketTunnelFlow) {
+    var isPersistent: Bool {
+        return true
+    }
+    
+    init(impl: NEPacketTunnelFlow?) {
         self.impl = impl
     }
     
@@ -21,20 +25,20 @@ class NETunnelInterface: TunnelInterface {
     }
     
     private func loopReadPackets(_ handler: @escaping ([Data]?, Error?) -> Void) {
-        impl.readPackets { [weak self] (packets, protocols) in
+        impl?.readPackets { [weak self] (packets, protocols) in
             handler(packets, nil)
             self?.loopReadPackets(handler)
         }
     }
     
     func writePacket(_ packet: Data, completionHandler: ((Error?) -> Void)?) {
-        impl.writePackets([packet], withProtocols: [AF_INET] as [NSNumber])
+        impl?.writePackets([packet], withProtocols: [AF_INET] as [NSNumber])
         completionHandler?(nil)
     }
     
     func writePackets(_ packets: [Data], completionHandler: ((Error?) -> Void)?) {
         let protocols = [Int32](repeating: AF_INET, count: packets.count) as [NSNumber]
-        impl.writePackets(packets, withProtocols: protocols)
+        impl?.writePackets(packets, withProtocols: protocols)
         completionHandler?(nil)
     }
 }

--- a/PIATunnel/Sources/AppExtension/Transport/NEUDPSocket.swift
+++ b/PIATunnel/Sources/AppExtension/Transport/NEUDPSocket.swift
@@ -21,9 +21,7 @@ class NEUDPSocket: NSObject, GenericSocket {
     
     private weak var queue: DispatchQueue?
     
-    var endpoint: NWEndpoint {
-        return impl.endpoint
-    }
+    let endpoint: NWEndpoint
     
     var remoteAddress: String? {
         return (impl.resolvedEndpoint as? NWHostEndpoint)?.hostname
@@ -37,6 +35,7 @@ class NEUDPSocket: NSObject, GenericSocket {
     
     init(impl: NWUDPSession) {
         self.impl = impl
+        endpoint = impl.endpoint
         isActive = false
     }
     

--- a/PIATunnel/Sources/Core/SessionProxy.swift
+++ b/PIATunnel/Sources/Core/SessionProxy.swift
@@ -341,7 +341,9 @@ public class SessionProxy {
         connectedDate = nil
         authenticator = nil
         link = nil
-        tunnel = nil
+        if !(tunnel?.isPersistent ?? false) {
+            tunnel = nil
+        }
         
         isStopping = false
         stopError = nil

--- a/PIATunnel/Sources/Core/TunnelInterface.swift
+++ b/PIATunnel/Sources/Core/TunnelInterface.swift
@@ -10,4 +10,7 @@ import Foundation
 
 /// Represents a specific I/O interface meant to work at the tunnel layer (e.g. VPN).
 public protocol TunnelInterface: IOInterface {
+
+    /// When `true`, interface survives sessions.
+    var isPersistent: Bool { get }
 }


### PR DESCRIPTION
This PR changes a few small things that may break behavior when a reconnection is initiated:

- Retains the necessary `SessionProxy` state to reinstate a connection (e.g. the CA file).
- Brings TUN down before shutting down the link, to ignore data packets coming from a stale connection.
- Fixes a race condition in TUN read handler resulting in a dead data channel.

Fixes #2 