### PR TITLE
Check error in TCP read before handling data

### DIFF
--- a/PIATunnel/Sources/AppExtension/Transport/NETCPInterface.swift
+++ b/PIATunnel/Sources/AppExtension/Transport/NETCPInterface.swift
@@ -52,7 +52,7 @@ class NETCPInterface: LinkInterface {
     
     private func loopReadPackets(_ buffer: Data, _ handler: @escaping ([Data]?, Error?) -> Void) {
         impl.readMinimumLength(2, maximumLength: packetBufferSize) { [weak self] (data, error) in
-            guard let data = data else {
+            guard (error == nil), let data = data else {
                 handler(nil, error)
                 return
             }


### PR DESCRIPTION
Data may be non-nil but shorter than minimum. Packetization may later raise an index OOB exception.