### PR TITLE
Merge transport implementations

### DIFF
--- a/PIATunnel/Sources/AppExtension/PIATunnelProvider.swift
+++ b/PIATunnel/Sources/AppExtension/PIATunnelProvider.swift
@@ -419,11 +419,11 @@ extension PIATunnelProvider {
         switch cfg.socketType {
         case .udp:
             let impl = createUDPSession(to: endpoint, from: nil)
-            return NEUDPSocket(impl: impl)
+            return NEUDPInterface(impl: impl)
             
         case .tcp:
             let impl = createTCPConnection(to: endpoint, enableTLS: false, tlsParameters: nil, delegate: nil)
-            return NETCPSocket(impl: impl)
+            return NETCPInterface(impl: impl)
         }
     }
     

--- a/PIATunnel/Sources/AppExtension/Transport/NETCPInterface.swift
+++ b/PIATunnel/Sources/AppExtension/Transport/NETCPInterface.swift
@@ -8,23 +8,148 @@
 
 import Foundation
 import NetworkExtension
+import SwiftyBeaver
 
-class NETCPInterface: LinkInterface {
+private let log = SwiftyBeaver.self
+
+class NETCPInterface: NSObject, GenericSocket, LinkInterface {
+    private static var linkContext = 0
+    
     private let impl: NWTCPConnection
     
     private let maxPacketSize: Int
+
+    init(impl: NWTCPConnection, maxPacketSize: Int = 32768) {
+        self.impl = impl
+        self.maxPacketSize = maxPacketSize
+        endpoint = impl.endpoint
+        isActive = false
+    }
+    
+    // MARK: GenericSocket
+    
+    private weak var queue: DispatchQueue?
+    
+    private var isActive: Bool
+    
+    let endpoint: NWEndpoint
+    
+    var remoteAddress: String? {
+        return (impl.remoteAddress as? NWHostEndpoint)?.hostname
+    }
+    
+    var hasBetterPath: Bool {
+        return impl.hasBetterPath
+    }
+    
+    weak var delegate: GenericSocketDelegate?
+    
+    func observe(queue: DispatchQueue, activeTimeout: Int) {
+        isActive = false
+        
+        self.queue = queue
+        queue.schedule(after: .milliseconds(activeTimeout)) { [weak self] in
+            guard let isActive = self?.isActive else {
+                return
+            }
+            guard isActive else {
+                log.debug("Socket timed out waiting for activity, cancelling...")
+                self?.impl.cancel()
+                return
+            }
+        }
+        impl.addObserver(self, forKeyPath: #keyPath(NWTCPConnection.state), options: [.initial, .new], context: &NETCPInterface.linkContext)
+        impl.addObserver(self, forKeyPath: #keyPath(NWTCPConnection.hasBetterPath), options: .new, context: &NETCPInterface.linkContext)
+    }
+    
+    func unobserve() {
+        impl.removeObserver(self, forKeyPath: #keyPath(NWTCPConnection.state), context: &NETCPInterface.linkContext)
+        impl.removeObserver(self, forKeyPath: #keyPath(NWTCPConnection.hasBetterPath), context: &NETCPInterface.linkContext)
+    }
+    
+    func shutdown() {
+        impl.writeClose()
+        impl.cancel()
+    }
+    
+    func upgraded() -> GenericSocket? {
+        guard impl.hasBetterPath else {
+            return nil
+        }
+        return NETCPInterface(impl: NWTCPConnection(upgradeFor: impl))
+    }
+    
+    func link() -> LinkInterface {
+        return self
+    }
+    
+    // MARK: Connection KVO (any queue)
+    
+    override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
+        guard (context == &NETCPInterface.linkContext) else {
+            super.observeValue(forKeyPath: keyPath, of: object, change: change, context: context)
+            return
+        }
+//        if let keyPath = keyPath {
+//            log.debug("KVO change reported (\(anyPointer(object)).\(keyPath))")
+//        }
+        queue?.async {
+            self.observeValueInTunnelQueue(forKeyPath: keyPath, of: object, change: change, context: context)
+        }
+    }
+    
+    private func observeValueInTunnelQueue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
+//        if let keyPath = keyPath {
+//            log.debug("KVO change reported (\(anyPointer(object)).\(keyPath))")
+//        }
+        guard let impl = object as? NWTCPConnection, (impl == self.impl) else {
+            log.warning("Discard KVO change from old socket")
+            return
+        }
+        guard let keyPath = keyPath else {
+            return
+        }
+        switch keyPath {
+        case #keyPath(NWTCPConnection.state):
+            if let resolvedEndpoint = impl.remoteAddress {
+                log.debug("Socket state is \(impl.state) (endpoint: \(impl.endpoint) -> \(resolvedEndpoint))")
+            } else {
+                log.debug("Socket state is \(impl.state) (endpoint: \(impl.endpoint) -> in progress)")
+            }
+            
+            switch impl.state {
+            case .connected:
+                isActive = true
+                delegate?.socketDidBecomeActive(self)
+                
+            case .cancelled:
+                delegate?.socket(self, didShutdownWithFailure: false)
+                
+            case .disconnected:
+                delegate?.socket(self, didShutdownWithFailure: true)
+                
+            default:
+                break
+            }
+            
+        case #keyPath(NWTCPConnection.hasBetterPath):
+            guard impl.hasBetterPath else {
+                break
+            }
+            log.debug("Socket has a better path")
+            delegate?.socketHasBetterPath(self)
+            
+        default:
+            break
+        }
+    }
+
+    // MARK: LinkInterface
     
     var isReliable: Bool {
         return true
     }
 
-    var remoteAddress: String? {
-        guard let endpoint = impl.remoteAddress as? NWHostEndpoint else {
-            return nil
-        }
-        return endpoint.hostname
-    }
-    
     var mtu: Int {
         return .max
     }
@@ -39,11 +164,6 @@ class NETCPInterface: LinkInterface {
     
     var hardResetTimeout: TimeInterval {
         return 5.0
-    }
-    
-    init(impl: NWTCPConnection, maxPacketSize: Int = 32768) {
-        self.impl = impl
-        self.maxPacketSize = maxPacketSize
     }
     
     func setReadHandler(_ handler: @escaping ([Data]?, Error?) -> Void) {

--- a/PIATunnel/Sources/AppExtension/Transport/NETCPInterface.swift
+++ b/PIATunnel/Sources/AppExtension/Transport/NETCPInterface.swift
@@ -146,25 +146,17 @@ class NETCPInterface: NSObject, GenericSocket, LinkInterface {
 
     // MARK: LinkInterface
     
-    var isReliable: Bool {
-        return true
-    }
+    let isReliable: Bool = true
 
-    var mtu: Int {
-        return .max
-    }
+    let mtu: Int = .max
     
     var packetBufferSize: Int {
         return maxPacketSize
     }
     
-    var negotiationTimeout: TimeInterval {
-        return 10.0
-    }
+    let negotiationTimeout: TimeInterval = 10.0
     
-    var hardResetTimeout: TimeInterval {
-        return 5.0
-    }
+    let hardResetTimeout: TimeInterval = 5.0
     
     func setReadHandler(_ handler: @escaping ([Data]?, Error?) -> Void) {
         loopReadPackets(Data(), handler)

--- a/PIATunnel/Sources/AppExtension/Transport/NEUDPInterface.swift
+++ b/PIATunnel/Sources/AppExtension/Transport/NEUDPInterface.swift
@@ -146,25 +146,17 @@ class NEUDPInterface: NSObject, GenericSocket, LinkInterface {
 
     // MARK: LinkInterface
     
-    var isReliable: Bool {
-        return false
-    }
+    let isReliable: Bool = false
     
-    var mtu: Int {
-        return 1000
-    }
+    let mtu: Int = 1000
 
     var packetBufferSize: Int {
         return maxDatagrams
     }
 
-    var negotiationTimeout: TimeInterval {
-        return 10.0
-    }
+    let negotiationTimeout: TimeInterval = 10.0
     
-    var hardResetTimeout: TimeInterval {
-        return 2.0
-    }
+    let hardResetTimeout: TimeInterval = 2.0
     
     func setReadHandler(_ handler: @escaping ([Data]?, Error?) -> Void) {
         impl.setReadHandler(handler, maxDatagrams: maxDatagrams)

--- a/PIATunnel/Sources/AppExtension/Transport/NEUDPInterface.swift
+++ b/PIATunnel/Sources/AppExtension/Transport/NEUDPInterface.swift
@@ -8,21 +8,146 @@
 
 import Foundation
 import NetworkExtension
+import SwiftyBeaver
 
-class NEUDPInterface: LinkInterface {
+private let log = SwiftyBeaver.self
+
+class NEUDPInterface: NSObject, GenericSocket, LinkInterface {
+    private static var linkContext = 0
+    
     private let impl: NWUDPSession
     
     private let maxDatagrams: Int
+
+    init(impl: NWUDPSession, maxDatagrams: Int = 200) {
+        self.impl = impl
+        self.maxDatagrams = maxDatagrams
+        endpoint = impl.endpoint
+        isActive = false
+    }
+    
+    // MARK: GenericSocket
+    
+    private weak var queue: DispatchQueue?
+    
+    private var isActive: Bool
+    
+    let endpoint: NWEndpoint
+    
+    var remoteAddress: String? {
+        return (impl.resolvedEndpoint as? NWHostEndpoint)?.hostname
+    }
+    
+    var hasBetterPath: Bool {
+        return impl.hasBetterPath
+    }
+    
+    weak var delegate: GenericSocketDelegate?
+    
+    func observe(queue: DispatchQueue, activeTimeout: Int) {
+        isActive = false
+        
+        self.queue = queue
+        queue.schedule(after: .milliseconds(activeTimeout)) { [weak self] in
+            guard let isActive = self?.isActive else {
+                return
+            }
+            guard isActive else {
+                log.debug("Socket timed out waiting for activity, fall back to next endpoint...")
+//                self?.impl.cancel()
+                self?.impl.tryNextResolvedEndpoint()
+                return
+            }
+        }
+        impl.addObserver(self, forKeyPath: #keyPath(NWUDPSession.state), options: [.initial, .new], context: &NEUDPInterface.linkContext)
+        impl.addObserver(self, forKeyPath: #keyPath(NWUDPSession.hasBetterPath), options: .new, context: &NEUDPInterface.linkContext)
+    }
+    
+    func unobserve() {
+        impl.removeObserver(self, forKeyPath: #keyPath(NWUDPSession.state), context: &NEUDPInterface.linkContext)
+        impl.removeObserver(self, forKeyPath: #keyPath(NWUDPSession.hasBetterPath), context: &NEUDPInterface.linkContext)
+    }
+    
+    func shutdown() {
+        impl.cancel()
+    }
+    
+    func upgraded() -> GenericSocket? {
+        guard impl.hasBetterPath else {
+            return nil
+        }
+        return NEUDPInterface(impl: NWUDPSession(upgradeFor: impl))
+    }
+    
+    func link() -> LinkInterface {
+        return self
+    }
+    
+    // MARK: Connection KVO (any queue)
+    
+    override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
+        guard (context == &NEUDPInterface.linkContext) else {
+            super.observeValue(forKeyPath: keyPath, of: object, change: change, context: context)
+            return
+        }
+//        if let keyPath = keyPath {
+//            log.debug("KVO change reported (\(anyPointer(object)).\(keyPath))")
+//        }
+        queue?.async {
+            self.observeValueInTunnelQueue(forKeyPath: keyPath, of: object, change: change, context: context)
+        }
+    }
+    
+    private func observeValueInTunnelQueue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
+//        if let keyPath = keyPath {
+//            log.debug("KVO change reported (\(anyPointer(object)).\(keyPath))")
+//        }
+        guard let impl = object as? NWUDPSession, (impl == self.impl) else {
+            log.warning("Discard KVO change from old socket")
+            return
+        }
+        guard let keyPath = keyPath else {
+            return
+        }
+        switch keyPath {
+        case #keyPath(NWUDPSession.state):
+            if let resolvedEndpoint = impl.resolvedEndpoint {
+                log.debug("Socket state is \(impl.state) (endpoint: \(impl.endpoint) -> \(resolvedEndpoint))")
+            } else {
+                log.debug("Socket state is \(impl.state) (endpoint: \(impl.endpoint) -> in progress)")
+            }
+            
+            switch impl.state {
+            case .ready:
+                isActive = true
+                delegate?.socketDidBecomeActive(self)
+                
+            case .cancelled:
+                delegate?.socket(self, didShutdownWithFailure: false)
+                
+            case .failed:
+                delegate?.socket(self, didShutdownWithFailure: true)
+                
+            default:
+                break
+            }
+            
+        case #keyPath(NWUDPSession.hasBetterPath):
+            guard impl.hasBetterPath else {
+                break
+            }
+            log.debug("Socket has a better path")
+            delegate?.socketHasBetterPath(self)
+            
+        default:
+            break
+        }
+    }
+
+    // MARK: LinkInterface
     
     var isReliable: Bool {
         return false
-    }
-    
-    var remoteAddress: String? {
-        guard let endpoint = impl.resolvedEndpoint as? NWHostEndpoint else {
-            return nil
-        }
-        return endpoint.hostname
     }
     
     var mtu: Int {
@@ -39,11 +164,6 @@ class NEUDPInterface: LinkInterface {
     
     var hardResetTimeout: TimeInterval {
         return 2.0
-    }
-    
-    init(impl: NWUDPSession, maxDatagrams: Int = 200) {
-        self.impl = impl
-        self.maxDatagrams = maxDatagrams
     }
     
     func setReadHandler(_ handler: @escaping ([Data]?, Error?) -> Void) {


### PR DESCRIPTION
Refactor to implement both `AppExtension` and `SessionProxy` business in the same objects, for simplicity. The underlying NetworkExtension objects can provide both `GenericSocket` and `LinkInterface` implementations.