### PR TITLE
Fall back to IPv4 on DNS failure

### DIFF
--- a/PIATunnel.xcodeproj/project.pbxproj
+++ b/PIATunnel.xcodeproj/project.pbxproj
@@ -37,6 +37,8 @@
 		0EBBF2FB2085061600E36B40 /* NETCPInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EBBF2F92085061600E36B40 /* NETCPInterface.swift */; };
 		0EBBF3002085196000E36B40 /* NWTCPConnectionState+Description.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EBBF2FF2085196000E36B40 /* NWTCPConnectionState+Description.swift */; };
 		0EBBF3012085196000E36B40 /* NWTCPConnectionState+Description.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EBBF2FF2085196000E36B40 /* NWTCPConnectionState+Description.swift */; };
+		0EC1BBA520D71190007C4C7B /* DNSResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EC1BBA420D71190007C4C7B /* DNSResolver.swift */; };
+		0EC1BBA620D712DE007C4C7B /* DNSResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EC1BBA420D71190007C4C7B /* DNSResolver.swift */; };
 		0EEC49DC20B5E732008FEB91 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EEC49DB20B5E732008FEB91 /* Utils.swift */; };
 		0EEC49DD20B5E732008FEB91 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EEC49DB20B5E732008FEB91 /* Utils.swift */; };
 		0EEC49E120B5F7EA008FEB91 /* Allocation.h in Headers */ = {isa = PBXBuildFile; fileRef = 0EFEB42E2006D3C800F81029 /* Allocation.h */; };
@@ -176,6 +178,7 @@
 		0EBBF2EC2085055100E36B40 /* NEUDPInterface.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NEUDPInterface.swift; sourceTree = "<group>"; };
 		0EBBF2F92085061600E36B40 /* NETCPInterface.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NETCPInterface.swift; sourceTree = "<group>"; };
 		0EBBF2FF2085196000E36B40 /* NWTCPConnectionState+Description.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NWTCPConnectionState+Description.swift"; sourceTree = "<group>"; };
+		0EC1BBA420D71190007C4C7B /* DNSResolver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DNSResolver.swift; sourceTree = "<group>"; };
 		0EEC49DB20B5E732008FEB91 /* Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
 		0EFEB42A2006D3C800F81029 /* EncryptionProxy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EncryptionProxy.swift; sourceTree = "<group>"; };
 		0EFEB42B2006D3C800F81029 /* SessionKey.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionKey.swift; sourceTree = "<group>"; };
@@ -393,6 +396,7 @@
 			isa = PBXGroup;
 			children = (
 				0EBBF2E32084FDF400E36B40 /* Transport */,
+				0EC1BBA420D71190007C4C7B /* DNSResolver.swift */,
 				0EBBF2E42084FE6F00E36B40 /* GenericSocket.swift */,
 				0EFEB4AA200760EC00F81029 /* InterfaceObserver.swift */,
 				0EFEB4AD2007625E00F81029 /* Keychain.swift */,
@@ -779,6 +783,7 @@
 				0EFEB4652006D3C800F81029 /* Authenticator.swift in Sources */,
 				0EEC49DC20B5E732008FEB91 /* Utils.swift in Sources */,
 				0EFEB4562006D3C800F81029 /* SessionKey.swift in Sources */,
+				0EC1BBA520D71190007C4C7B /* DNSResolver.swift in Sources */,
 				0EFEB4AB200760EC00F81029 /* MemoryDestination.swift in Sources */,
 				0EFEB4AE2007625E00F81029 /* Keychain.swift in Sources */,
 				0EBBF3002085196000E36B40 /* NWTCPConnectionState+Description.swift in Sources */,
@@ -823,6 +828,7 @@
 				0EFEB4882006D7C400F81029 /* PIATunnelProvider+Interaction.swift in Sources */,
 				0EEC49DD20B5E732008FEB91 /* Utils.swift in Sources */,
 				0EFEB4B12007627700F81029 /* MemoryDestination.swift in Sources */,
+				0EC1BBA620D712DE007C4C7B /* DNSResolver.swift in Sources */,
 				0EFEB4A02006D7F300F81029 /* ReplayProtector.m in Sources */,
 				0EFEB4992006D7F300F81029 /* SessionProxy.swift in Sources */,
 				0EBBF3012085196000E36B40 /* NWTCPConnectionState+Description.swift in Sources */,

--- a/PIATunnel/Sources/AppExtension/DNSResolver.swift
+++ b/PIATunnel/Sources/AppExtension/DNSResolver.swift
@@ -1,0 +1,72 @@
+//
+//  DNSResolver.swift
+//  PIATunnel
+//
+//  Created by Davide De Rosa on 12/15/17.
+//  Copyright © 2017 London Trust Media. All rights reserved.
+//
+
+import Foundation
+
+class DNSResolver {
+    private static let queue = DispatchQueue(label: "DNSResolver")
+
+    static func resolve(_ hostname: String, timeout: Int, completionHandler: @escaping ([String]?, Error?) -> Void) {
+        var pendingHandler: (([String]?, Error?) -> Void)? = completionHandler
+        let host = CFHostCreateWithName(nil, hostname as CFString).takeRetainedValue()
+        DNSResolver.queue.async {
+            CFHostStartInfoResolution(host, .addresses, nil)
+            guard let handler = pendingHandler else {
+                return
+            }
+            DNSResolver.didResolve(host: host, completionHandler: handler)
+            pendingHandler = nil
+        }
+        DNSResolver.queue.asyncAfter(deadline: .now() + .milliseconds(timeout)) {
+            guard let handler = pendingHandler else {
+                return
+            }
+            CFHostCancelInfoResolution(host, .addresses)
+            handler(nil, nil)
+            pendingHandler = nil
+        }
+    }
+    
+    private static func didResolve(host: CFHost, completionHandler: @escaping ([String]?, Error?) -> Void) {
+        var success: DarwinBoolean = false
+        guard let rawAddresses = CFHostGetAddressing(host, &success)?.takeUnretainedValue() as Array? else {
+            completionHandler(nil, nil)
+            return
+        }
+        
+        var ipAddresses: [String] = []
+        for case var rawAddress as Data in rawAddresses {
+            var ipAddress = [CChar](repeating: 0, count: Int(NI_MAXHOST))
+            let result = rawAddress.withUnsafeBytes { (addr: UnsafePointer<sockaddr>) in
+                return getnameinfo(
+                    addr,
+                    socklen_t(rawAddress.count),
+                    &ipAddress,
+                    socklen_t(ipAddress.count),
+                    nil,
+                    0,
+                    NI_NUMERICHOST
+                )
+            }
+            guard result == 0 else {
+                continue
+            }
+            ipAddresses.append(String(cString: ipAddress))
+        }
+        completionHandler(ipAddresses, nil)
+    }
+
+    static func string(fromIPv4 ipv4: UInt32) -> String {
+        let a = UInt8(ipv4) & 0xff
+        let b = UInt8(ipv4 >> 8) & 0xff
+        let c = UInt8(ipv4 >> 16) & 0xff
+        let d = UInt8(ipv4 >> 24) & 0xff
+
+        return "\(a).\(b).\(c).\(d)"
+    }
+}

--- a/PIATunnel/Sources/AppExtension/GenericSocket.swift
+++ b/PIATunnel/Sources/AppExtension/GenericSocket.swift
@@ -22,7 +22,7 @@ protocol GenericSocketDelegate: class {
 }
 
 protocol GenericSocket: LinkProducer {
-    var endpoint: NWEndpoint { get }
+    var endpoint: NWHostEndpoint { get }
     
     var remoteAddress: String? { get }
     

--- a/PIATunnel/Sources/AppExtension/PIATunnelProvider+Interaction.swift
+++ b/PIATunnel/Sources/AppExtension/PIATunnelProvider+Interaction.swift
@@ -52,6 +52,9 @@ extension PIATunnelProvider {
         /// The TLS certificate could not be serialized.
         case certificateSerialization
         
+        /// Socket endpoint could not be resolved.
+        case dnsFailure
+        
         /// Socket failed to reach active state.
         case socketActivity
         

--- a/PIATunnel/Sources/AppExtension/PIATunnelProvider.swift
+++ b/PIATunnel/Sources/AppExtension/PIATunnelProvider.swift
@@ -225,14 +225,22 @@ open class PIATunnelProvider: NEPacketTunnelProvider {
 
     private func connectTunnel(hostname: String, port: String) {
         log.info("Creating link session")
-        let endpoint = resolvedEndpoint(hostname: hostname, port: port)
-        log.info("Will connect to \(endpoint)")
-        
-        let targetSocket = upgradedSocket ?? genericSocket(endpoint: endpoint)
-        log.info("Socket type is \(type(of: targetSocket))")
-        if let _ = upgradedSocket {
+
+        let targetSocket: GenericSocket
+        if let upgradedSocket = upgradedSocket {
+            targetSocket = upgradedSocket
             log.info("Socket follows a path upgrade")
+        } else {
+            let endpoint = resolvedEndpoint(hostname: hostname, port: port)
+            targetSocket = genericSocket(endpoint: endpoint)
         }
+        connectTunnel(via: targetSocket)
+    }
+    
+    private func connectTunnel(via targetSocket: GenericSocket) {
+        log.info("Will connect to \(targetSocket.endpoint)")
+
+        log.info("Socket type is \(type(of: targetSocket))")
         socket = targetSocket
         upgradedSocket = nil
         socket?.delegate = self

--- a/PIATunnel/Sources/AppExtension/PIATunnelProvider.swift
+++ b/PIATunnel/Sources/AppExtension/PIATunnelProvider.swift
@@ -166,7 +166,7 @@ open class PIATunnelProvider: NEPacketTunnelProvider {
 
         pendingStartHandler = completionHandler
         tunnelQueue.sync {
-            self.connectTunnel(endpoint: NWHostEndpoint(hostname: endpoint.hostname, port: endpoint.port))
+            self.connectTunnel(hostname: endpoint.hostname, port: endpoint.port)
         }
     }
     
@@ -210,8 +210,9 @@ open class PIATunnelProvider: NEPacketTunnelProvider {
     
     // MARK: Connection (tunnel queue)
 
-    private func connectTunnel(endpoint: NWEndpoint) {
+    private func connectTunnel(hostname: String, port: String) {
         log.info("Creating link session")
+        let endpoint = NWHostEndpoint(hostname: hostname, port: port)
         log.info("Will connect to \(endpoint)")
         
         let targetSocket = upgradedSocket ?? genericSocket(endpoint: endpoint)
@@ -310,7 +311,7 @@ extension PIATunnelProvider: GenericSocketDelegate {
             }
             log.debug("Disconnection is recoverable, tunnel will reconnect in \(reconnectionDelay) milliseconds...")
             tunnelQueue.schedule(after: .milliseconds(reconnectionDelay)) {
-                self.connectTunnel(endpoint: socket.endpoint)
+                self.connectTunnel(hostname: socket.endpoint.hostname, port: socket.endpoint.port)
             }
             return
         }
@@ -417,7 +418,7 @@ extension PIATunnelProvider {
         }
     }
     
-    private func genericSocket(endpoint: NWEndpoint) -> GenericSocket {
+    private func genericSocket(endpoint: NWHostEndpoint) -> GenericSocket {
         switch cfg.socketType {
         case .udp:
             let impl = createUDPSession(to: endpoint, from: nil)

--- a/PIATunnel/Sources/AppExtension/PIATunnelProvider.swift
+++ b/PIATunnel/Sources/AppExtension/PIATunnelProvider.swift
@@ -209,10 +209,23 @@ open class PIATunnelProvider: NEPacketTunnelProvider {
     }
     
     // MARK: Connection (tunnel queue)
+    
+    private func resolvedEndpoint(hostname: String, port: String) -> NWHostEndpoint {
+        guard cfg.prefersResolvedAddresses else {
+            return NWHostEndpoint(hostname: hostname, port: port)
+        }
+        guard let addresses = cfg.resolvedAddresses, !addresses.isEmpty else {
+            assertionFailure("Found unexpected empty resolvedAddresses in configuration")
+            return NWHostEndpoint(hostname: hostname, port: port)
+        }
+        let n = Int(arc4random() % UInt32(addresses.count))
+        let address = addresses[n]
+        return NWHostEndpoint(hostname: address, port: port)
+    }
 
     private func connectTunnel(hostname: String, port: String) {
         log.info("Creating link session")
-        let endpoint = NWHostEndpoint(hostname: hostname, port: port)
+        let endpoint = resolvedEndpoint(hostname: hostname, port: port)
         log.info("Will connect to \(endpoint)")
         
         let targetSocket = upgradedSocket ?? genericSocket(endpoint: endpoint)

--- a/PIATunnel/Sources/AppExtension/Transport/NETCPInterface.swift
+++ b/PIATunnel/Sources/AppExtension/Transport/NETCPInterface.swift
@@ -22,7 +22,10 @@ class NETCPInterface: NSObject, GenericSocket, LinkInterface {
     init(impl: NWTCPConnection, maxPacketSize: Int = 32768) {
         self.impl = impl
         self.maxPacketSize = maxPacketSize
-        endpoint = impl.endpoint
+        guard let hostEndpoint = impl.endpoint as? NWHostEndpoint else {
+            fatalError("Expected a NWHostEndpoint")
+        }
+        endpoint = hostEndpoint
         isActive = false
     }
     
@@ -32,7 +35,7 @@ class NETCPInterface: NSObject, GenericSocket, LinkInterface {
     
     private var isActive: Bool
     
-    let endpoint: NWEndpoint
+    let endpoint: NWHostEndpoint
     
     var remoteAddress: String? {
         return (impl.remoteAddress as? NWHostEndpoint)?.hostname

--- a/PIATunnel/Sources/AppExtension/Transport/NEUDPInterface.swift
+++ b/PIATunnel/Sources/AppExtension/Transport/NEUDPInterface.swift
@@ -22,7 +22,10 @@ class NEUDPInterface: NSObject, GenericSocket, LinkInterface {
     init(impl: NWUDPSession, maxDatagrams: Int = 200) {
         self.impl = impl
         self.maxDatagrams = maxDatagrams
-        endpoint = impl.endpoint
+        guard let hostEndpoint = impl.endpoint as? NWHostEndpoint else {
+            fatalError("Expected a NWHostEndpoint")
+        }
+        endpoint = hostEndpoint
         isActive = false
     }
     
@@ -32,7 +35,7 @@ class NEUDPInterface: NSObject, GenericSocket, LinkInterface {
     
     private var isActive: Bool
     
-    let endpoint: NWEndpoint
+    let endpoint: NWHostEndpoint
     
     var remoteAddress: String? {
         return (impl.resolvedEndpoint as? NWHostEndpoint)?.hostname

--- a/PIATunnelTests/AppExtensionTests.swift
+++ b/PIATunnelTests/AppExtensionTests.swift
@@ -65,4 +65,19 @@ class AppExtensionTests: XCTestCase {
         XCTAssertEqual(proto?.providerConfiguration?[K.debug] as? Bool, cfg.shouldDebug)
         XCTAssertEqual(proto?.providerConfiguration?[K.debugLogKey] as? String, cfg.debugLogKey)
     }
+    
+    func testDNSResolver() {
+        let exp = expectation(description: "DNS")
+        DNSResolver.resolve("djsbjhcbjzhbxjnvsd.com", timeout: 1000) { (addrs, error) in
+            defer {
+                exp.fulfill()
+            }
+            guard let addrs = addrs else {
+                print("Can't resolve")
+                return
+            }
+            print("\(addrs)")
+        }
+        waitForExpectations(timeout: 5.0, handler: nil)
+    }
 }


### PR DESCRIPTION
Inject a manual DNS step because NetworkExtension doesn't provide a way to tell if a TCP socket fails for DNS failure or port unreachable. Take advantage of this addition to implement hostname -> IPv4 fallback.

Also add an explicit configuration field to skip DNS resolution altogether (`prefersResolvedAddresses`).