### PR TITLE
TUN read handler race

### DIFF
--- a/PIATunnel/Sources/AppExtension/PIATunnelProvider.swift
+++ b/PIATunnel/Sources/AppExtension/PIATunnelProvider.swift
@@ -151,7 +151,6 @@ open class PIATunnelProvider: NEPacketTunnelProvider {
         let proxy: SessionProxy
         do {
             proxy = try SessionProxy(queue: tunnelQueue, encryption: encryption, credentials: credentials)
-            proxy.setTunnel(tunnel: NETunnelInterface(impl: packetFlow))
         } catch let e {
             completionHandler(e)
             return
@@ -365,6 +364,8 @@ extension PIATunnelProvider: SessionProxyDelegate {
             
             log.info("Tunnel interface is now UP")
             
+            proxy.setTunnel(tunnel: NETunnelInterface(impl: self.packetFlow))
+
             self.pendingStartHandler?(nil)
             self.pendingStartHandler = nil
         }

--- a/PIATunnel/Sources/AppExtension/Transport/NETunnelInterface.swift
+++ b/PIATunnel/Sources/AppExtension/Transport/NETunnelInterface.swift
@@ -13,7 +13,7 @@ class NETunnelInterface: TunnelInterface {
     private weak var impl: NEPacketTunnelFlow?
     
     var isPersistent: Bool {
-        return true
+        return false
     }
     
     init(impl: NEPacketTunnelFlow) {

--- a/PIATunnel/Sources/Core/IOInterface.swift
+++ b/PIATunnel/Sources/Core/IOInterface.swift
@@ -14,9 +14,10 @@ public protocol IOInterface {
     /**
      Sets the handler for incoming packets. This only needs to be set once.
 
+     - Parameter queue: The queue where to invoke the handler on.
      - Parameter handler: The handler invoked whenever an array of `Data` packets is received, with an optional `Error` in case a network failure occurs.
      */
-    func setReadHandler(_ handler: @escaping ([Data]?, Error?) -> Void)
+    func setReadHandler(queue: DispatchQueue, _ handler: @escaping ([Data]?, Error?) -> Void)
     
     /**
      Writes a packet to the interface.

--- a/PIATunnel/Sources/Core/SessionProxy.swift
+++ b/PIATunnel/Sources/Core/SessionProxy.swift
@@ -397,40 +397,32 @@ public class SessionProxy {
 
     // Ruby: udp_loop
     private func loopLink() {
-
-        // WARNING: runs in Network.framework queue
-        link?.setReadHandler { [weak self] (newPackets, error) in
+        link?.setReadHandler(queue: queue) { [weak self] (newPackets, error) in
             if let error = error {
                 log.error("Failed LINK read: \(error)")
                 return
             }
             
             if let packets = newPackets, !packets.isEmpty {
-                self?.queue.sync {
-                    self?.maybeRenegotiate()
+                self?.maybeRenegotiate()
 
-//                    log.verbose("Received \(packets.count) packets from \(self.linkName)")
-                    self?.receiveLink(packets: packets)
-                }
+//                log.verbose("Received \(packets.count) packets from \(self.linkName)")
+                self?.receiveLink(packets: packets)
             }
         }
     }
 
     // Ruby: tun_loop
     private func loopTunnel() {
-        
-        // WARNING: runs in NEPacketTunnelFlow queue
-        tunnel?.setReadHandler { [weak self] (newPackets, error) in
+        tunnel?.setReadHandler(queue: queue) { [weak self] (newPackets, error) in
             if let error = error {
                 log.error("Failed TUN read: \(error)")
                 return
             }
 
             if let packets = newPackets, !packets.isEmpty {
-                self?.queue.sync {
-//                    log.verbose("Received \(packets.count) packets from \(self.tunnelName)")
-                    self?.receiveTunnel(packets: packets)
-                }
+//                log.verbose("Received \(packets.count) packets from \(self.tunnelName)")
+                self?.receiveTunnel(packets: packets)
             }
         }
     }


### PR DESCRIPTION
Strange things seem to happen in PIA VPN 2.6 after many network switches. As described in 53d0f28, `NETunnelInterface` could end up in a situation where the packet reading loop would die, thus making the VPN appear connected yet with no data exchange.

Code-wise, upon reconnection, the second invocation of `NEPacketTunnelFlow.readPackets()` was at times triggering the completion handler of a pending `readPackets()` from the superseded connection. That way, the newer `NETunnelInterface` object was stuck waiting forever for a read to complete.

By debugging the deferred loop code, it turns out that `readPackets()` was being invoked from different queues, specifically:

- `PIATunnelProvider.tunnelQueue` in `setReadHandler()`
- `NEPacketTunnelFlow` queue in `loopReadPackets()`

Now, the Apple documentation of NetworkExtension is very scarce and doesn't say a word about thread-safety of `NEPacketTunnelFlow`, so better be safe than sorry: always execute the completion handler in a single explicit queue. That way, `readPackets()` invocations won't overlap, which might well be the root cause of the bad completion handler callback.
