### PR TITLE
Support vanilla servers

### DIFF
--- a/PIATunnel/Sources/Core/SessionProxy.swift
+++ b/PIATunnel/Sources/Core/SessionProxy.swift
@@ -126,7 +126,16 @@ public class SessionProxy {
     
     private let credentials: Credentials
     
-    private let encodedSettings: Data
+    /// Set to `true` if server is a PIA-patched server. Default `true`.
+    public var isPIAServer: Bool
+    
+    private var encodedSettings: Data {
+        guard isPIAServer else {
+            return Data()
+        }
+        let settings = TunnelSettings(caMd5Digest: encryption.caDigest, cipherName: encryption.cipherName, digestName: encryption.digestName)
+        return (try? settings.encodedData()) ?? Data()
+    }
     
     /// The number of seconds after which a renegotiation should be initiated. If `nil`, the client will never initiate a renegotiation.
     public var renegotiatesAfter: TimeInterval?
@@ -219,9 +228,7 @@ public class SessionProxy {
         self.encryption = encryption
         self.credentials = credentials
 
-        encodedSettings = try TunnelSettings(caMd5Digest: encryption.caDigest,
-                                             cipherName: encryption.cipherName,
-                                             digestName: encryption.digestName).encodedData()
+        isPIAServer = true
         renegotiatesAfter = nil
         
         keys = [:]

--- a/PIATunnel/Sources/Core/TLSBox.m
+++ b/PIATunnel/Sources/Core/TLSBox.m
@@ -82,7 +82,7 @@ int TLSBoxVerifyPeer(int ok, X509_STORE_CTX *ctx) {
         TLSBoxIsOpenSSLLoaded = YES;
     }
     
-    self.ctx = SSL_CTX_new(SSLv23_client_method());
+    self.ctx = SSL_CTX_new(TLS_client_method());
     SSL_CTX_set_options(self.ctx, SSL_OP_NO_SSLv2|SSL_OP_NO_SSLv3|SSL_OP_NO_COMPRESSION);
     if (peerVerification && self.caPath) {
         SSL_CTX_set_verify(self.ctx, SSL_VERIFY_PEER, TLSBoxVerifyPeer);


### PR DESCRIPTION
At the very least, must skip the PIA extra bytes sent with HARD_RESET.