### PR TITLE
Cancel DNS resolution properly

### DIFF
--- a/PIATunnel/Sources/AppExtension/ConnectionStrategy.swift
+++ b/PIATunnel/Sources/AppExtension/ConnectionStrategy.swift
@@ -32,7 +32,12 @@ class ConnectionStrategy {
         endpointProtocols = configuration.endpointProtocols
     }
 
-    func createSocket(from provider: NEProvider, timeout: Int, preferredAddress: String? = nil, completionHandler: @escaping (GenericSocket?, Error?) -> Void) {
+    func createSocket(
+        from provider: NEProvider,
+        timeout: Int,
+        preferredAddress: String? = nil,
+        queue: DispatchQueue,
+        completionHandler: @escaping (GenericSocket?, Error?) -> Void) {
         
         // reuse preferred address
         if let preferredAddress = preferredAddress {
@@ -52,8 +57,8 @@ class ConnectionStrategy {
         
         // fall back to DNS
         log.debug("DNS resolve hostname: \(hostname)")
-        DNSResolver.resolve(hostname, timeout: timeout) { (addresses, error) in
-
+        DNSResolver.resolve(hostname, timeout: timeout, queue: queue) { (addresses, error) in
+            
             // refresh resolved addresses
             if let resolved = addresses, !resolved.isEmpty {
                 self.resolvedAddresses = resolved

--- a/PIATunnel/Sources/AppExtension/DNSResolver.swift
+++ b/PIATunnel/Sources/AppExtension/DNSResolver.swift
@@ -22,13 +22,15 @@ class DNSResolver {
             DNSResolver.didResolve(host: host, completionHandler: handler)
             pendingHandler = nil
         }
-        DNSResolver.queue.asyncAfter(deadline: .now() + .milliseconds(timeout)) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(timeout)) {
             guard let handler = pendingHandler else {
                 return
             }
             CFHostCancelInfoResolution(host, .addresses)
-            handler(nil, nil)
-            pendingHandler = nil
+            DNSResolver.queue.sync {
+                handler(nil, nil)
+                pendingHandler = nil
+            }
         }
     }
     

--- a/PIATunnel/Sources/AppExtension/DNSResolver.swift
+++ b/PIATunnel/Sources/AppExtension/DNSResolver.swift
@@ -8,10 +8,11 @@
 
 import Foundation
 
-class DNSResolver {
+/// :nodoc:
+public class DNSResolver {
     private static let queue = DispatchQueue(label: "DNSResolver")
 
-    static func resolve(_ hostname: String, timeout: Int, queue: DispatchQueue, completionHandler: @escaping ([String]?, Error?) -> Void) {
+    public static func resolve(_ hostname: String, timeout: Int, queue: DispatchQueue, completionHandler: @escaping ([String]?, Error?) -> Void) {
         var pendingHandler: (([String]?, Error?) -> Void)? = completionHandler
         let host = CFHostCreateWithName(nil, hostname as CFString).takeRetainedValue()
         DNSResolver.queue.async {

--- a/PIATunnel/Sources/AppExtension/PIATunnelProvider.swift
+++ b/PIATunnel/Sources/AppExtension/PIATunnelProvider.swift
@@ -219,7 +219,7 @@ open class PIATunnelProvider: NEPacketTunnelProvider {
             return
         }
         
-        strategy.createSocket(from: self, timeout: dnsTimeout, preferredAddress: preferredAddress) { (socket, error) in
+        strategy.createSocket(from: self, timeout: dnsTimeout, preferredAddress: preferredAddress, queue: tunnelQueue) { (socket, error) in
             guard let socket = socket else {
                 self.disposeTunnel(error: error)
                 return

--- a/PIATunnelTests/AppExtensionTests.swift
+++ b/PIATunnelTests/AppExtensionTests.swift
@@ -67,7 +67,7 @@ class AppExtensionTests: XCTestCase {
     
     func testDNSResolver() {
         let exp = expectation(description: "DNS")
-        DNSResolver.resolve("djsbjhcbjzhbxjnvsd.com", timeout: 1000) { (addrs, error) in
+        DNSResolver.resolve("djsbjhcbjzhbxjnvsd.com", timeout: 1000, queue: DispatchQueue.main) { (addrs, error) in
             defer {
                 exp.fulfill()
             }


### PR DESCRIPTION
DNS is not timing out because cancel is being issued on the very same queue that's blocked by DNS.