### PR TITLE
Use faster data implementations

### DIFF
--- a/PIATunnel/Sources/AppExtension/Transport/NETCPInterface.swift
+++ b/PIATunnel/Sources/AppExtension/Transport/NETCPInterface.swift
@@ -184,7 +184,7 @@ class NETCPInterface: NSObject, GenericSocket, LinkInterface {
                 var newBuffer = buffer
                 newBuffer.append(contentsOf: data)
                 let (until, packets) = ControlPacket.parsed(newBuffer)
-                newBuffer.removeSubrange(0..<until)
+                newBuffer = newBuffer.subdata(in: until..<newBuffer.count)
                 self?.loopReadPackets(queue, newBuffer, handler)
 
                 handler(packets, nil)

--- a/PIATunnel/Sources/Core/Authenticator.swift
+++ b/PIATunnel/Sources/Core/Authenticator.swift
@@ -106,7 +106,7 @@ class Authenticator {
         let serverRandom2 = controlBuffer.withOffset(offset, count: Configuration.randomLength)
         offset += Configuration.randomLength
         
-        let serverOptsLength = Int(CFSwapInt16BigToHost(controlBuffer.uint16Value(fromOffset: offset)))
+        let serverOptsLength = Int(controlBuffer.networkUInt16Value(fromOffset: offset))
         offset += 2
         
         let serverOpts = controlBuffer.withOffset(offset, count: serverOptsLength)

--- a/PIATunnel/Sources/Core/Data+Manipulation.swift
+++ b/PIATunnel/Sources/Core/Data+Manipulation.swift
@@ -116,8 +116,8 @@ extension Data {
         return value
     }
     
-    // best
-    func UInt32Value(from: Int) -> UInt32 {
+    @available(*, deprecated)
+    func UInt32ValueFromBuffer(from: Int) -> UInt32 {
         var value: UInt32 = 0
         for i in 0..<4 {
             let byte = self[from + i]
@@ -128,8 +128,8 @@ extension Data {
         return value
     }
     
-    @available(*, deprecated)
-    func UInt32ValueFromPointers(from: Int) -> UInt32 {
+    // best
+    func UInt32Value(from: Int) -> UInt32 {
         return subdata(in: from..<(from + 4)).withUnsafeBytes { $0.pointee }
     }
 

--- a/PIATunnel/Sources/Core/Data+Manipulation.swift
+++ b/PIATunnel/Sources/Core/Data+Manipulation.swift
@@ -145,6 +145,18 @@ extension Data {
 //        print("value: \(String(format: "%x", value))")
         return value
     }
+
+    func networkUInt16Value(from: Int) -> UInt16 {
+        return UInt16(bigEndian: subdata(in: from..<(from + 2)).withUnsafeBytes {
+            $0.pointee
+        })
+    }
+
+    func networkUInt32Value(from: Int) -> UInt32 {
+        return UInt32(bigEndian: subdata(in: from..<(from + 4)).withUnsafeBytes {
+            $0.pointee
+        })
+    }
 }
 
 extension Data {

--- a/PIATunnel/Sources/Core/HighLevelDataPath.swift
+++ b/PIATunnel/Sources/Core/HighLevelDataPath.swift
@@ -96,7 +96,7 @@ class HighLevelDataPath: DataPath {
 //            log.verbose("Data: Decrypted packet (\(decryptedPacket.count) bytes)")
             
             var offset = 0
-            let packetId = CFSwapInt32BigToHost(decryptedPacket.UInt32Value(from: offset))
+            let packetId = decryptedPacket.networkUInt32Value(from: offset)
             offset += 4
             
 //            let compression = decryptedPacket[offset]

--- a/PIATunnel/Sources/Core/Packet.swift
+++ b/PIATunnel/Sources/Core/Packet.swift
@@ -47,8 +47,7 @@ class ControlPacket: Packet {
         var ni = 0
         var parsed: [Data] = []
         while (ni + 2 <= stream.count) {
-            let networkPacklen = stream.UInt16Value(from: ni)
-            let packlen = Int(CFSwapInt16BigToHost(networkPacklen))
+            let packlen = Int(stream.networkUInt16Value(from: ni))
             let start = ni + 2
             let end = start + packlen
             guard (end <= stream.count) else {

--- a/PIATunnel/Sources/Core/SessionProxy.swift
+++ b/PIATunnel/Sources/Core/SessionProxy.swift
@@ -474,7 +474,7 @@ public class SessionProxy {
             if (ackSize > 0) {
                 var ackedPacketIds = [UInt32]()
                 for _ in 0..<ackSize {
-                    let ackedPacketId = CFSwapInt32BigToHost(packet.UInt32Value(from: offset))
+                    let ackedPacketId = packet.networkUInt32Value(from: offset)
                     ackedPacketIds.append(ackedPacketId)
                     offset += ProtocolMacros.packetIdLength
                 }
@@ -490,7 +490,7 @@ public class SessionProxy {
                 return
             }
 
-            let packetId = CFSwapInt32BigToHost(packet.UInt32Value(from: offset))
+            let packetId = packet.networkUInt32Value(from: offset)
             log.debug("Control packet has packetId \(packetId)")
             offset += ProtocolMacros.packetIdLength
 

--- a/PIATunnel/Sources/Core/ZeroingData.h
+++ b/PIATunnel/Sources/Core/ZeroingData.h
@@ -30,7 +30,8 @@
 
 - (nonnull ZeroingData *)appendingData:(ZeroingData *)other;
 - (nonnull ZeroingData *)withOffset:(NSInteger)offset count:(NSInteger)count;
-- (uint16_t)uint16ValueFromOffset:(NSInteger)from;
+- (uint16_t)UInt16ValueFromOffset:(NSInteger)from;
+- (uint16_t)networkUInt16ValueFromOffset:(NSInteger)from;
 - (NSString *)nullTerminatedStringFromOffset:(NSInteger)from;
 
 - (BOOL)isEqualToData:(NSData *)data;

--- a/PIATunnel/Sources/Core/ZeroingData.m
+++ b/PIATunnel/Sources/Core/ZeroingData.m
@@ -201,7 +201,7 @@
     return [[ZeroingData alloc] initWithBytesNoCopy:newBytes count:count];
 }
 
-- (uint16_t)uint16ValueFromOffset:(NSInteger)from
+- (uint16_t)UInt16ValueFromOffset:(NSInteger)from
 {
     NSParameterAssert(from + 2 <= _count);
 
@@ -209,6 +209,16 @@
     value |= _bytes[from];
     value |= _bytes[from + 1] << 8;
     return value;
+}
+
+- (uint16_t)networkUInt16ValueFromOffset:(NSInteger)from
+{
+    NSParameterAssert(from + 2 <= _count);
+    
+    uint16_t value = 0;
+    value |= _bytes[from];
+    value |= _bytes[from + 1] << 8;
+    return CFSwapInt16BigToHost(value);
 }
 
 - (NSString *)nullTerminatedStringFromOffset:(NSInteger)from

--- a/PIATunnelTests/DataManipulationTests.swift
+++ b/PIATunnelTests/DataManipulationTests.swift
@@ -28,9 +28,9 @@ class DataManipulationTests: XCTestCase {
         XCTAssertEqual(data.UInt32Value(from: 0), 0xbbaaff22)
         
         XCTAssertEqual(data.UInt16Value(from: 3), data.UInt16ValueFromPointers(from: 3))
-        XCTAssertEqual(data.UInt32Value(from: 2), data.UInt32ValueFromPointers(from: 2))
+        XCTAssertEqual(data.UInt32Value(from: 2), data.UInt32ValueFromBuffer(from: 2))
         XCTAssertEqual(data.UInt16Value(from: 4), data.UInt16ValueFromPointers(from: 4))
-        XCTAssertEqual(data.UInt32Value(from: 0), data.UInt32ValueFromPointers(from: 0))
+        XCTAssertEqual(data.UInt32Value(from: 0), data.UInt32ValueFromBuffer(from: 0))
     }
     
     func testZeroingData() {

--- a/PIATunnelTests/RawPerformanceTests.swift
+++ b/PIATunnelTests/RawPerformanceTests.swift
@@ -49,7 +49,7 @@ class RawPerformanceTests: XCTestCase {
         
         measure {
             for _ in 0..<1000000 {
-                let _ = data.UInt32Value(from: 1)
+                let _ = data.UInt32ValueFromBuffer(from: 1)
             }
         }
     }
@@ -60,7 +60,7 @@ class RawPerformanceTests: XCTestCase {
         
         measure {
             for _ in 0..<1000000 {
-                let _ = data.UInt32ValueFromPointers(from: 1)
+                let _ = data.UInt32Value(from: 1)
             }
         }
     }

--- a/PIATunnelTests/RawPerformanceTests.swift
+++ b/PIATunnelTests/RawPerformanceTests.swift
@@ -98,7 +98,8 @@ class RawPerformanceTests: XCTestCase {
         let suite = TestUtils.generateDataSuite(1000, 200000)
         measure {
             for data in suite {
-                let _ = UInt32(bigEndian: data.subdata(in: 0..<4).withUnsafeBytes { $0.pointee })
+//                let _ = UInt32(bigEndian: data.subdata(in: 0..<4).withUnsafeBytes { $0.pointee })
+                let _ = data.networkUInt32Value(from: 0)
             }
         }
     }


### PR DESCRIPTION
- Deprecate data manipulation methods proved to be slower.
- Add some convenience methods for big-endian parsing (network byte order).