### PR TITLE
Re-add support for secp256k1

### DIFF
--- a/PIATunnel/Sources/AppExtension/PIATunnelProvider+Configuration.swift
+++ b/PIATunnel/Sources/AppExtension/PIATunnelProvider+Configuration.swift
@@ -62,7 +62,7 @@ extension PIATunnelProvider {
         case ecc256r1 = "ECC-256r1"
         
         /// Certificate with ECC based on secp256k1 curve.
-//        case ecc256k1 = "ECC-256k1"
+        case ecc256k1 = "ECC-256k1"
 
         /// Certificate with ECC based on secp521r1 curve.
         case ecc521r1 = "ECC-521r1"
@@ -77,7 +77,7 @@ extension PIATunnelProvider {
             .rsa3072: "2fcdb65712df9db7dae34a1f4a84e32d",
             .rsa4096: "ec085790314aa0ad4b01dda7b756a932",
             .ecc256r1: "6f0f23a616479329ce54614f76b52254",
-//            .ecc256k1: "80c3b0f34001e4101e34fde9eb1dfa87",
+            .ecc256k1: "80c3b0f34001e4101e34fde9eb1dfa87",
             .ecc521r1: "82446e0c80706e33e6e793cebf1b0c59"
         ]
         

--- a/PIATunnel/Sources/Core/TLSBox.m
+++ b/PIATunnel/Sources/Core/TLSBox.m
@@ -97,7 +97,8 @@ int TLSBoxVerifyPeer(int ok, X509_STORE_CTX *ctx) {
     else {
         SSL_CTX_set_verify(self.ctx, SSL_VERIFY_NONE, NULL);
     }
-    
+    SSL_CTX_set1_curves_list(self.ctx, "X25519:prime256v1:secp521r1:secp384r1:secp256k1");
+
     self.ssl = SSL_new(self.ctx);
     
     self.bioPlainText = BIO_new(BIO_f_ssl());

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The client is known to work with [OpenVPN®][openvpn] 2.3+ servers. Key renegoti
     - SHA-256
 - [x] TLS CA validation (read below)
     - RSA (2048, 3072 and 4096 bit)
-    - ECC (sec256r1, sec521r1)
+    - ECC (secp256r1, secp521r1, secp256k1)
     - Custom certificate
 
 Theoretically, any custom CA can be fed to the client for TLS validation. When using the AppExtension module though, the handshake is restricted to the embedded root certificates from PIA.


### PR DESCRIPTION
Disabled out of the box in OpenSSL 1.1.0.