### PR TITLE
Rebind floating socket on path upgrade

### DIFF
--- a/PIATunnel/Sources/AppExtension/GenericSocket.swift
+++ b/PIATunnel/Sources/AppExtension/GenericSocket.swift
@@ -32,6 +32,8 @@ protocol GenericSocket: LinkProducer {
     
     var hasBetterPath: Bool { get }
     
+    var isShutdown: Bool { get }
+
     var delegate: GenericSocketDelegate? { get set }
 
     func observe(queue: DispatchQueue, activeTimeout: Int)

--- a/PIATunnel/Sources/AppExtension/PIATunnelProvider.swift
+++ b/PIATunnel/Sources/AppExtension/PIATunnelProvider.swift
@@ -75,8 +75,6 @@ open class PIATunnelProvider: NEPacketTunnelProvider {
     
     private var socket: GenericSocket?
 
-    private var upgradedSocket: GenericSocket?
-    
     private var linkFailures = 0
 
     private var pendingStartHandler: ((Error?) -> Void)?
@@ -223,11 +221,11 @@ open class PIATunnelProvider: NEPacketTunnelProvider {
     
     // MARK: Connection (tunnel queue)
     
-    private func connectTunnel(preferredAddress: String? = nil) {
+    private func connectTunnel(upgradedSocket: GenericSocket? = nil, preferredAddress: String? = nil) {
         log.info("Creating link session")
         
         // reuse upgraded socket
-        if let upgradedSocket = upgradedSocket {
+        if let upgradedSocket = upgradedSocket, !upgradedSocket.isShutdown {
             log.debug("Socket follows a path upgrade")
             connectTunnel(via: upgradedSocket)
             return
@@ -247,13 +245,14 @@ open class PIATunnelProvider: NEPacketTunnelProvider {
 
         log.debug("Socket type is \(type(of: socket))")
         self.socket = socket
-        upgradedSocket = nil
         self.socket?.delegate = self
         self.socket?.observe(queue: tunnelQueue, activeTimeout: socketTimeout)
     }
     
     private func finishTunnelDisconnection(error: Error?) {
-        proxy?.cleanup()
+        if let proxy = proxy, !(reasserting && proxy.canRebindLink()) {
+            proxy.cleanup()
+        }
         
         socket?.delegate = nil
         socket?.unobserve()
@@ -323,13 +322,24 @@ extension PIATunnelProvider: GenericSocketDelegate {
     }
     
     func socketDidBecomeActive(_ socket: GenericSocket) {
-        proxy?.setLink(socket.link())
+        guard let proxy = proxy else {
+            return
+        }
+        if proxy.canRebindLink() {
+            proxy.rebindLink(socket.link())
+            reasserting = false
+        } else {
+            proxy.setLink(socket.link())
+        }
     }
     
     func socket(_ socket: GenericSocket, didShutdownWithFailure failure: Bool) {
         guard let proxy = proxy else {
             return
         }
+        
+        // upgrade available?
+        let upgradedSocket = socket.upgraded()
         
         var shutdownError: Error?
         if !failure {
@@ -355,7 +365,7 @@ extension PIATunnelProvider: GenericSocketDelegate {
             }
             log.debug("Disconnection is recoverable, tunnel will reconnect in \(reconnectionDelay) milliseconds...")
             tunnelQueue.schedule(after: .milliseconds(reconnectionDelay)) {
-                self.connectTunnel(preferredAddress: socket.endpoint.hostname)
+                self.connectTunnel(upgradedSocket: upgradedSocket, preferredAddress: socket.endpoint.hostname)
             }
             return
         }
@@ -365,8 +375,7 @@ extension PIATunnelProvider: GenericSocketDelegate {
     func socketHasBetterPath(_ socket: GenericSocket) {
         log.debug("Stopping tunnel due to a new better path")
         logCurrentSSID()
-        upgradedSocket = socket.upgraded()
-        proxy?.shutdown(error: ProviderError.networkChanged)
+        proxy?.reconnect(error: ProviderError.networkChanged)
     }
 }
 

--- a/PIATunnel/Sources/AppExtension/PIATunnelProvider.swift
+++ b/PIATunnel/Sources/AppExtension/PIATunnelProvider.swift
@@ -323,7 +323,7 @@ extension PIATunnelProvider: GenericSocketDelegate {
     }
     
     func socketDidBecomeActive(_ socket: GenericSocket) {
-        proxy?.setLink(link: socket.link())
+        proxy?.setLink(socket.link())
     }
     
     func socket(_ socket: GenericSocket, didShutdownWithFailure failure: Bool) {

--- a/PIATunnel/Sources/AppExtension/Transport/NETCPInterface.swift
+++ b/PIATunnel/Sources/AppExtension/Transport/NETCPInterface.swift
@@ -123,6 +123,9 @@ class NETCPInterface: NSObject, GenericSocket, LinkInterface {
             
             switch impl.state {
             case .connected:
+                guard !isActive else {
+                    return
+                }
                 isActive = true
                 delegate?.socketDidBecomeActive(self)
                 

--- a/PIATunnel/Sources/AppExtension/Transport/NETCPInterface.swift
+++ b/PIATunnel/Sources/AppExtension/Transport/NETCPInterface.swift
@@ -28,6 +28,7 @@ class NETCPInterface: NSObject, GenericSocket, LinkInterface {
         }
         endpoint = hostEndpoint
         isActive = false
+        isShutdown = false
     }
     
     // MARK: GenericSocket
@@ -35,6 +36,8 @@ class NETCPInterface: NSObject, GenericSocket, LinkInterface {
     private weak var queue: DispatchQueue?
     
     private var isActive: Bool
+    
+    private(set) var isShutdown: Bool
     
     let endpoint: NWHostEndpoint
     
@@ -130,9 +133,11 @@ class NETCPInterface: NSObject, GenericSocket, LinkInterface {
                 delegate?.socketDidBecomeActive(self)
                 
             case .cancelled:
+                isShutdown = true
                 delegate?.socket(self, didShutdownWithFailure: false)
                 
             case .disconnected:
+                isShutdown = true
                 delegate?.socket(self, didShutdownWithFailure: true)
                 
             default:

--- a/PIATunnel/Sources/AppExtension/Transport/NEUDPInterface.swift
+++ b/PIATunnel/Sources/AppExtension/Transport/NEUDPInterface.swift
@@ -33,6 +33,7 @@ class NEUDPInterface: NSObject, GenericSocket, LinkInterface {
         }
         endpoint = hostEndpoint
         isActive = false
+        isShutdown = false
     }
     
     // MARK: GenericSocket
@@ -41,6 +42,8 @@ class NEUDPInterface: NSObject, GenericSocket, LinkInterface {
     
     private var isActive: Bool
     
+    private(set) var isShutdown: Bool
+
     let endpoint: NWHostEndpoint
     
     var remoteAddress: String? {
@@ -133,9 +136,11 @@ class NEUDPInterface: NSObject, GenericSocket, LinkInterface {
                 delegate?.socketDidBecomeActive(self)
                 
             case .cancelled:
+                isShutdown = true
                 delegate?.socket(self, didShutdownWithFailure: false)
                 
             case .failed:
+                isShutdown = true
 //                if timedOut {
 //                    delegate?.socketShouldChangeProtocol(self)
 //                }

--- a/PIATunnel/Sources/AppExtension/Transport/NEUDPInterface.swift
+++ b/PIATunnel/Sources/AppExtension/Transport/NEUDPInterface.swift
@@ -126,6 +126,9 @@ class NEUDPInterface: NSObject, GenericSocket, LinkInterface {
             
             switch impl.state {
             case .ready:
+                guard !isActive else {
+                    return
+                }
                 isActive = true
                 delegate?.socketDidBecomeActive(self)
                 

--- a/PIATunnel/Sources/Core/IOInterface.swift
+++ b/PIATunnel/Sources/Core/IOInterface.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// Represents an I/O interface able to read and write data.
-public protocol IOInterface {
+public protocol IOInterface: class {
 
     /**
      Sets the handler for incoming packets. This only needs to be set once.

--- a/PIATunnel/Sources/Core/SessionProxy.swift
+++ b/PIATunnel/Sources/Core/SessionProxy.swift
@@ -257,7 +257,7 @@ public class SessionProxy {
      - Postcondition: The VPN negotiation is started.
      - Parameter link: The `LinkInterface` on which to establish the VPN session.
      */
-    public func setLink(link: LinkInterface) {
+    public func setLink(_ link: LinkInterface) {
         guard (self.link == nil) else {
             log.warning("Link interface already set!")
             return
@@ -276,6 +276,37 @@ public class SessionProxy {
         start()
     }
     
+    /**
+     Returns `true` if the current session can rebind to a new link with `rebindLink(...)`.
+
+     - Returns: `true` if supports link rebinding.
+     */
+    public func canRebindLink() -> Bool {
+        return (peerId != nil)
+    }
+    
+    /**
+     Rebinds the session to a new link if supported.
+     
+     - Precondition: `link` is an active network interface.
+     - Postcondition: The VPN session is active.
+     - Parameter link: The `LinkInterface` on which to establish the VPN session.
+     - Seealso: `canRebindLink()`.
+     */
+    public func rebindLink(_ link: LinkInterface) {
+        guard let _ = peerId else {
+            log.warning("Session doesn't support link rebinding!")
+            return
+        }
+
+        isStopping = false
+        stopError = nil
+
+        log.debug("Rebinding VPN session to a new link")
+        self.link = link
+        loopLink()
+    }
+
     /**
      Establishes the tunnel interface for this session. The interface must be up and running for sending and receiving packets.
      

--- a/PIATunnel/Sources/Core/SessionProxy.swift
+++ b/PIATunnel/Sources/Core/SessionProxy.swift
@@ -434,7 +434,12 @@ public class SessionProxy {
 
     // Ruby: udp_loop
     private func loopLink() {
-        link?.setReadHandler(queue: queue) { [weak self] (newPackets, error) in
+        let loopedLink = link
+        loopedLink?.setReadHandler(queue: queue) { [weak self] (newPackets, error) in
+            guard loopedLink === self?.link else {
+                log.warning("Ignoring read from outdated LINK")
+                return
+            }
             if let error = error {
                 log.error("Failed LINK read: \(error)")
                 return


### PR DESCRIPTION
Try to avoid a new negotiation when the session is floating (= has a peer-id) and the VPN disconnects due to a path upgrade (e.g. 4G to Wi-Fi).