### PR TITLE
implement client certificate support

### DIFF
--- a/PIATunnel/Sources/AppExtension/PIATunnelProvider+Configuration.swift
+++ b/PIATunnel/Sources/AppExtension/PIATunnelProvider+Configuration.swift
@@ -225,6 +225,12 @@ extension PIATunnelProvider {
         /// The custom CA certificate in PEM format in case `handshake == .custom`. Ignored otherwise.
         public var ca: String?
         
+        /// The client certificate
+        public var cert: String?
+        
+        /// The key for the client certificate
+        public var key: String?
+        
         /// The MTU of the tunnel.
         public var mtu: NSNumber
         
@@ -258,6 +264,8 @@ extension PIATunnelProvider {
             digest = .sha1
             handshake = .rsa2048
             ca = nil
+            cert = nil
+            key = nil
             mtu = 1500
             renegotiatesAfterSeconds = nil
             shouldDebug = false
@@ -289,6 +297,16 @@ extension PIATunnelProvider {
                     throw ProviderError.configuration(field: "protocolConfiguration.providerConfiguration[\(S.ca)]")
                 }
                 self.ca = ca
+                
+                guard let cert = providerConfiguration[S.cert] as? String else {
+                        throw ProviderError.configuration(field: "protocolConfiguration.providerConfiguration[\(S.cert)]")
+                }
+                self.cert = cert
+                
+                guard let key = providerConfiguration[S.key] as? String else {
+                        throw ProviderError.configuration(field: "protocolConfiguration.providerConfiguration[\(S.key)]")
+                }
+                self.key = key
             }
 
             self.appGroup = appGroup
@@ -355,6 +373,8 @@ extension PIATunnelProvider {
                 digest: digest,
                 handshake: handshake,
                 ca: ca,
+                cert: cert,
+                key: key,
                 mtu: mtu,
                 renegotiatesAfterSeconds: renegotiatesAfterSeconds,
                 shouldDebug: shouldDebug,
@@ -382,6 +402,10 @@ extension PIATunnelProvider {
             static let handshakeCertificate = "HandshakeCertificate"
             
             static let ca = "CA"
+            
+            static let cert = "CERT"
+            
+            static let key = "KEY"
             
             static let mtu = "MTU"
             
@@ -417,6 +441,10 @@ extension PIATunnelProvider {
         
         /// - Seealso: `PIATunnelProvider.ConfigurationBuilder.ca`
         public let ca: String?
+        
+        public let cert: String?
+        
+        public let key: String?
         
         /// - Seealso: `PIATunnelProvider.ConfigurationBuilder.mtu`
         public let mtu: NSNumber
@@ -482,6 +510,12 @@ extension PIATunnelProvider {
             ]
             if let ca = ca {
                 dict[S.ca] = ca
+            }
+            if let cert = cert {
+                dict[S.cert] = cert
+            }
+            if let key = key {
+                dict[S.key] = key
             }
             if let resolvedAddresses = resolvedAddresses {
                 dict[S.resolvedAddresses] = resolvedAddresses

--- a/PIATunnel/Sources/Core/SessionProxy.swift
+++ b/PIATunnel/Sources/Core/SessionProxy.swift
@@ -93,15 +93,21 @@ public class SessionProxy {
         /// The path to the CA for TLS negotiation (PEM format).
         public let caPath: String
 
+        public let certPath: String
+        
+        public let keyPath: String
+        
         /// The MD5 digest of the CA (computed from DER format).
         public let caDigest: String?
 
         /// :nodoc:
-        public init(_ cipherName: String, _ digestName: String, _ caPath: String, _ caDigest: String?) {
+        public init(_ cipherName: String, _ digestName: String, _ caPath: String, _ certPath: String, _ keyPath: String, _ caDigest: String?) {
             self.cipherName = cipherName
             self.digestName = digestName
             self.caPath = caPath
             self.caDigest = caDigest
+            self.certPath = certPath
+            self.keyPath = keyPath
         }
     }
     
@@ -825,7 +831,7 @@ public class SessionProxy {
             log.debug("Remote sessionId is \(remoteSessionId.toHex())")
             log.debug("Start TLS handshake")
 
-            negotiationKey.tlsOptional = TLSBox(caPath: encryption.caPath)
+            negotiationKey.tlsOptional = TLSBox(caPath: encryption.caPath, certPath: encryption.certPath, keyPath: encryption.keyPath)
             do {
                 try negotiationKey.tls.start(withPeerVerification: true)
             } catch let e {

--- a/PIATunnel/Sources/Core/TLSBox.h
+++ b/PIATunnel/Sources/Core/TLSBox.h
@@ -20,7 +20,7 @@ extern NSString *const TLSBoxPeerVerificationErrorNotification;
 //
 @interface TLSBox : NSObject
 
-- (nonnull instancetype)initWithCAPath:(NSString *)caPath;
+- (nonnull instancetype)initWithCAPath:(NSString *)caPath certPath:(NSString *) certPath_ keyPath:(NSString *) keyPath_;
 
 - (BOOL)startWithPeerVerification:(BOOL)peerVerification error:(NSError **)error;
 


### PR DESCRIPTION
for use with OpenVPN servers requiring TLS client certificate authentication.

You can define a key `cert` and `key` in the Demo application to make this
work.

This is an initial version, I'm not a Objective C / Swift programmer and the TLS client certificate authentication should be made optional. I am also not sure about the OpenSSL error handling. Patch may require substantial work still, but it *DOES* work with the Demo app.