### PR TITLE
Keep existing item if password unchanged

### DIFF
--- a/PIATunnel/Sources/AppExtension/Keychain.swift
+++ b/PIATunnel/Sources/AppExtension/Keychain.swift
@@ -41,6 +41,11 @@ public class Keychain {
     // MARK: Password
     
     public func set(password: String, for username: String, label: String? = nil) throws {
+        let currentPassword = try password(for: username)
+        guard password != currentPassword else {
+            return
+        }
+
         removePassword(for: username)
         
         var query = [String: Any]()


### PR DESCRIPTION
Prevents a new keychain prompt in case the user has formerly allowed keychain access to the extension.