### PR TITLE
support IPv6 DNS addresses

### DIFF
--- a/PIATunnel/Sources/Core/PushReply.swift
+++ b/PIATunnel/Sources/Core/PushReply.swift
@@ -11,7 +11,7 @@ import Foundation
 struct PushReply {
     private static let ifconfigRegexp = try! NSRegularExpression(pattern: "ifconfig [\\d\\.]+ [\\d\\.]+", options: [])
 
-    private static let dnsRegexp = try! NSRegularExpression(pattern: "dhcp-option DNS [\\d\\.]+", options: [])
+    private static let dnsRegexp = try! NSRegularExpression(pattern: "dhcp-option (DNS|DNS6) ([\\d\\.]|[a-fA-F0-9:])+", options: [])
 
     private static let authTokenRegexp = try! NSRegularExpression(pattern: "auth-token [a-zA-Z0-9/=+]+", options: [])
 


### PR DESCRIPTION
OpenVPN servers can push IPv6 DNS addresses through the
DNS or DNS6 dhcp-option. NE will handle both IPv4 and
IPv6 addresses. This is initial work on supporting IPv6.