### PR TITLE
Work around confusing NWEndpoint downcast failure

### DIFF
--- a/PIATunnel/Sources/AppExtension/GenericSocket.swift
+++ b/PIATunnel/Sources/AppExtension/GenericSocket.swift
@@ -7,7 +7,6 @@
 //
 
 import Foundation
-import NetworkExtension
 
 protocol LinkProducer {
     func link() -> LinkInterface
@@ -26,8 +25,6 @@ protocol GenericSocketDelegate: class {
 }
 
 protocol GenericSocket: LinkProducer {
-    var endpoint: NWHostEndpoint { get }
-    
     var remoteAddress: String? { get }
     
     var hasBetterPath: Bool { get }

--- a/PIATunnel/Sources/AppExtension/PIATunnelProvider.swift
+++ b/PIATunnel/Sources/AppExtension/PIATunnelProvider.swift
@@ -242,7 +242,7 @@ open class PIATunnelProvider: NEPacketTunnelProvider {
     }
     
     private func connectTunnel(via socket: GenericSocket) {
-        log.info("Will connect to \(socket.endpoint)")
+        log.info("Will connect to \(socket)")
 
         log.debug("Socket type is \(type(of: socket))")
         self.socket = socket
@@ -366,7 +366,7 @@ extension PIATunnelProvider: GenericSocketDelegate {
             }
             log.debug("Disconnection is recoverable, tunnel will reconnect in \(reconnectionDelay) milliseconds...")
             tunnelQueue.schedule(after: .milliseconds(reconnectionDelay)) {
-                self.connectTunnel(upgradedSocket: upgradedSocket, preferredAddress: socket.endpoint.hostname)
+                self.connectTunnel(upgradedSocket: upgradedSocket, preferredAddress: socket.remoteAddress)
             }
             return
         }

--- a/PIATunnel/Sources/AppExtension/Transport/NETCPInterface.swift
+++ b/PIATunnel/Sources/AppExtension/Transport/NETCPInterface.swift
@@ -23,10 +23,6 @@ class NETCPInterface: NSObject, GenericSocket, LinkInterface {
         self.impl = impl
         self.communicationType = communicationType
         self.maxPacketSize = maxPacketSize ?? (512 * 1024)
-        guard let hostEndpoint = impl.endpoint as? NWHostEndpoint else {
-            fatalError("Expected a NWHostEndpoint")
-        }
-        endpoint = hostEndpoint
         isActive = false
         isShutdown = false
     }
@@ -38,8 +34,6 @@ class NETCPInterface: NSObject, GenericSocket, LinkInterface {
     private var isActive: Bool
     
     private(set) var isShutdown: Bool
-    
-    let endpoint: NWHostEndpoint
     
     var remoteAddress: String? {
         return (impl.remoteAddress as? NWHostEndpoint)?.hostname
@@ -212,5 +206,14 @@ class NETCPInterface: NSObject, GenericSocket, LinkInterface {
         impl.write(stream) { (error) in
             completionHandler?(error)
         }
+    }
+}
+
+extension NETCPInterface {
+    override var description: String {
+        guard let hostEndpoint = impl.endpoint as? NWHostEndpoint else {
+            return impl.endpoint.description
+        }
+        return "\(hostEndpoint.hostname):\(hostEndpoint.port)"
     }
 }

--- a/PIATunnel/Sources/AppExtension/Transport/NEUDPInterface.swift
+++ b/PIATunnel/Sources/AppExtension/Transport/NEUDPInterface.swift
@@ -28,10 +28,6 @@ class NEUDPInterface: NSObject, GenericSocket, LinkInterface {
             self.maxDatagrams = maxDatagrams ?? 200
         }
 
-        guard let hostEndpoint = impl.endpoint as? NWHostEndpoint else {
-            fatalError("Expected a NWHostEndpoint")
-        }
-        endpoint = hostEndpoint
         isActive = false
         isShutdown = false
     }
@@ -44,8 +40,6 @@ class NEUDPInterface: NSObject, GenericSocket, LinkInterface {
     
     private(set) var isShutdown: Bool
 
-    let endpoint: NWHostEndpoint
-    
     var remoteAddress: String? {
         return (impl.resolvedEndpoint as? NWHostEndpoint)?.hostname
     }
@@ -201,5 +195,14 @@ class NEUDPInterface: NSObject, GenericSocket, LinkInterface {
         impl.writeMultipleDatagrams(packets) { (error) in
             completionHandler?(error)
         }
+    }
+}
+
+extension NEUDPInterface {
+    override var description: String {
+        guard let hostEndpoint = impl.endpoint as? NWHostEndpoint else {
+            return impl.endpoint.description
+        }
+        return "\(hostEndpoint.hostname):\(hostEndpoint.port)"
     }
 }


### PR DESCRIPTION
The following may occasionally fail in production:

    guard let hostEndpoint = impl.endpoint as? NWHostEndpoint else {
        fatalError("Expected a NWHostEndpoint")
    }

Don't ask me why or even how to reproduce it. Given that the fatalError() is there for debugging purposes and that `.endpoint` is not really needed, this PR kind of gets rid of it instead of trying to dangerously fit it in.